### PR TITLE
chore(release): bump to version `v0.9.0`

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "flow-think": {

--- a/templates/codex/mcp-config.json
+++ b/templates/codex/mcp-config.json
@@ -2,16 +2,18 @@
   "_comment": [
     "Flow Think MCP Server Configuration for Codex CLI",
     "",
-    "Codex CLI MCP configuration for flow-think structured thinking.",
-    "Merge this into your ~/.codex/config.json mcpServers section.",
+    "The installer generates runtime-aware config automatically.",
+    "Standalone mode (preferred): command = ~/.flow/mcp/flow-think/flow-think-mcp",
+    "Node.js fallback: command = node, args = [~/.flow/mcp/flow-think/index.js]",
     "",
     "See: tools/flow-think/README.md for full documentation"
   ],
 
   "mcpServers": {
     "flow-think": {
-      "command": "bun",
-      "args": ["run", "~/.flow/mcp/flow-think/dist/index.js"],
+      "_comment": "Standalone executable (no runtime required) — installer auto-detects",
+      "command": "~/.flow/mcp/flow-think/flow-think-mcp",
+      "args": [],
       "env": {
         "FLOW_MCP_BEADS_SYNC": "true",
         "FLOW_MCP_OUTPUT_FORMAT": "console"

--- a/templates/codex/mcp-config.toml
+++ b/templates/codex/mcp-config.toml
@@ -1,11 +1,20 @@
 # Flow Framework - Codex CLI MCP Configuration
 #
-# This file provides MCP server configuration for Codex CLI.
-# Add these configurations to ~/.codex/config.toml
+# This file documents the MCP server configuration for Codex CLI.
+# The installer (install.sh) generates runtime-aware config automatically.
+#
+# Standalone mode (preferred — no runtime required):
+#   [mcp_servers.flow-think]
+#   command = "~/.flow/mcp/flow-think/flow-think-mcp"
+#   args = []
+#
+# Node.js fallback (when Bun standalone not available):
+#   [mcp_servers.flow-think]
+#   command = "node"
+#   args = ["~/.flow/mcp/flow-think/index.js"]
 #
 # Installation:
-#   1. Append this to your ~/.codex/config.toml
-#   2. Or run: ./tools/scripts/install.sh (auto-merges)
+#   Run: ./tools/scripts/install.sh (auto-configures based on available runtime)
 #
 # Documentation: https://developers.openai.com/codex/mcp/
 
@@ -14,8 +23,8 @@
 # revision support, and Beads integration for complex problem-solving.
 
 [mcp_servers.flow-think]
-command = "bun"
-args = ["run", "${FLOW_INSTALL_PATH}/tools/flow-think/src/index.ts"]
+command = "${FLOW_MCP_COMMAND}"
+args = [${FLOW_MCP_ARGS}]
 startup_timeout_sec = 15
 tool_timeout_sec = 120
 

--- a/templates/opencode/mcp-config.json
+++ b/templates/opencode/mcp-config.json
@@ -2,7 +2,10 @@
   "_comment": [
     "Flow Think MCP Server Configuration for OpenCode",
     "",
-    "OpenCode MCP configuration for flow-think structured thinking.",
+    "The installer generates runtime-aware config automatically.",
+    "Standalone mode (preferred): command = ~/.flow/mcp/flow-think/flow-think-mcp",
+    "Node.js fallback: command = node, args = [~/.flow/mcp/flow-think/index.js]",
+    "",
     "Merge this into your ~/.config/opencode/config.json mcpServers section.",
     "",
     "See: tools/flow-think/README.md for full documentation"
@@ -10,8 +13,9 @@
 
   "mcpServers": {
     "flow-think": {
-      "command": "bun",
-      "args": ["run", "~/.flow/mcp/flow-think/dist/index.js"],
+      "_comment": "Standalone executable (no runtime required) — installer auto-detects",
+      "command": "~/.flow/mcp/flow-think/flow-think-mcp",
+      "args": [],
       "env": {
         "FLOW_MCP_BEADS_SYNC": "true",
         "FLOW_MCP_OUTPUT_FORMAT": "console"

--- a/tools/flow-think/package.json
+++ b/tools/flow-think/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-think-mcp",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "description": "MCP server for structured thinking in Flow - Cascaded Reasoning with Adaptive Step Handling",
   "type": "module",
   "main": "dist/index.js",

--- a/tools/flow-think/scripts/build.sh
+++ b/tools/flow-think/scripts/build.sh
@@ -62,9 +62,42 @@ if command -v bun &> /dev/null; then
 else
     echo -e "    ${YELLOW}Bun not available, falling back to tsc${NC}"
 
-    # Run TypeScript compiler
+    # Ensure dependencies are installed
+    if [[ ! -d "node_modules" ]]; then
+        echo "    Installing dependencies..."
+        if command -v npm &>/dev/null; then
+            npm install --ignore-scripts 2>/dev/null || {
+                echo -e "    ${RED}Failed to install dependencies${NC}"
+                exit 1
+            }
+        else
+            echo -e "    ${RED}npm not found — install Node.js or Bun${NC}"
+            exit 1
+        fi
+    fi
+
+    # Create dist directory
+    mkdir -p dist
+
+    # Run TypeScript compiler (try tsc directly, then npx)
     echo "    Compiling TypeScript..."
-    npx tsc
+    if command -v tsc &>/dev/null; then
+        tsc || { echo -e "    ${RED}tsc compilation failed${NC}"; exit 1; }
+    elif command -v npx &>/dev/null; then
+        npx tsc || { echo -e "    ${RED}npx tsc compilation failed${NC}"; exit 1; }
+    else
+        echo -e "    ${RED}tsc not found — install typescript or use Bun${NC}"
+        exit 1
+    fi
+
+    # Add shebang for direct execution (if not already present)
+    if [[ -f dist/index.js ]] && ! head -1 dist/index.js | grep -q '^#!'; then
+        echo "    Adding shebang..."
+        TEMP_FILE=$(mktemp)
+        echo '#!/usr/bin/env node' > "$TEMP_FILE"
+        cat dist/index.js >> "$TEMP_FILE"
+        mv "$TEMP_FILE" dist/index.js
+    fi
 
     BUILD_MODE="compiled"
 fi

--- a/tools/flow-think/src/beads/detection.ts
+++ b/tools/flow-think/src/beads/detection.ts
@@ -7,6 +7,7 @@
 
 import { existsSync } from "fs";
 import { join } from "path";
+import { spawn } from "../runtime.js";
 
 /**
  * Status of Beads availability.
@@ -56,14 +57,8 @@ export class BeadsDetection {
     }
 
     try {
-      // Use Bun's shell for subprocess
-      const proc = Bun.spawn(["which", "bd"], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const exitCode = await proc.exited;
-      installedCache = exitCode === 0;
+      const result = await spawn(["which", "bd"]);
+      installedCache = result.exitCode === 0;
 
       if (installedCache) {
         console.error("🔗 Beads CLI detected");
@@ -73,13 +68,8 @@ export class BeadsDetection {
     } catch {
       // If which fails (e.g., Windows without which), try running bd --version
       try {
-        const proc = Bun.spawn(["bd", "--version"], {
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-
-        const exitCode = await proc.exited;
-        installedCache = exitCode === 0;
+        const result = await spawn(["bd", "--version"]);
+        installedCache = result.exitCode === 0;
         return installedCache;
       } catch {
         installedCache = false;

--- a/tools/flow-think/src/beads/restoration.ts
+++ b/tools/flow-think/src/beads/restoration.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FlowThinkStep } from "../types.js";
+import { spawn } from "../runtime.js";
 import { BeadsDetection } from "./detection.js";
 import { parseBeadsNote } from "./types.js";
 
@@ -86,21 +87,18 @@ export class BeadsRestoration {
    */
   private async fetchEpicNotes(epicId: string): Promise<string | null> {
     try {
-      const proc = Bun.spawn(["bd", "show", epicId], {
-        stdout: "pipe",
-        stderr: "pipe",
-        cwd: this.workingDirectory,
-      });
+      const result = await spawn(
+        ["bd", "show", epicId],
+        { cwd: this.workingDirectory }
+      );
 
-      const exitCode = await proc.exited;
-      if (exitCode !== 0) {
+      if (result.exitCode !== 0) {
         return null;
       }
 
-      const stdout = await new Response(proc.stdout).text();
-
       // Extract notes section from output
       // bd show output format includes a "Notes:" section
+      const stdout = result.stdout ?? "";
       const notesMatch = stdout.match(/Notes:\s*\n([\s\S]*?)(?=\n\w+:|$)/);
       return notesMatch ? notesMatch[1].trim() : null;
     } catch {

--- a/tools/flow-think/src/beads/session-manager.ts
+++ b/tools/flow-think/src/beads/session-manager.ts
@@ -4,6 +4,7 @@
  * Manages mapping between MCP sessions and Beads epics.
  */
 
+import { spawn } from "../runtime.js";
 import { BeadsDetection } from "./detection.js";
 
 /**
@@ -121,19 +122,16 @@ export class BeadsSessionManager {
     }
 
     try {
-      const proc = Bun.spawn(["bd", "show", epicId, "--format", "json"], {
-        stdout: "pipe",
-        stderr: "pipe",
-        cwd: this.workingDirectory,
-      });
+      const result = await spawn(
+        ["bd", "show", epicId, "--format", "json"],
+        { cwd: this.workingDirectory }
+      );
 
-      const exitCode = await proc.exited;
-      if (exitCode !== 0) {
+      if (result.exitCode !== 0) {
         return null;
       }
 
-      const stdout = await new Response(proc.stdout).text();
-      const data = JSON.parse(stdout);
+      const data = JSON.parse(result.stdout ?? "{}");
 
       return {
         id: epicId,

--- a/tools/flow-think/src/beads/sync.ts
+++ b/tools/flow-think/src/beads/sync.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FlowThinkStep } from "../types.js";
+import { spawn } from "../runtime.js";
 import { BeadsDetection } from "./detection.js";
 import { formatStepForBeads, type BeadsSyncStatus } from "./types.js";
 
@@ -193,20 +194,13 @@ export class BeadsSync {
    * Uses `bd update --append-notes` to add the note.
    */
   private async executeSync(epicId: string, note: string): Promise<void> {
-    // Escape the note for shell
-    const escapedNote = note.replace(/'/g, "'\\''");
+    const result = await spawn(
+      ["bd", "update", epicId, "--append-notes", note],
+      { cwd: this.workingDirectory }
+    );
 
-    const proc = Bun.spawn(["bd", "update", epicId, "--append-notes", escapedNote], {
-      stdout: "pipe",
-      stderr: "pipe",
-      cwd: this.workingDirectory,
-    });
-
-    const exitCode = await proc.exited;
-
-    if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      throw new Error(`bd update failed: ${stderr}`);
+    if (result.exitCode !== 0) {
+      throw new Error(`bd update failed: ${result.stderr ?? "unknown error"}`);
     }
 
     console.error(`📝 Synced step to Beads epic ${epicId}`);

--- a/tools/flow-think/src/runtime.ts
+++ b/tools/flow-think/src/runtime.ts
@@ -141,7 +141,11 @@ export function logRuntime(): void {
  */
 export async function spawn(
   command: string[],
-  options: { stdout?: "pipe" | "inherit"; stderr?: "pipe" | "inherit" } = {}
+  options: {
+    stdout?: "pipe" | "inherit";
+    stderr?: "pipe" | "inherit";
+    cwd?: string;
+  } = {}
 ): Promise<{ exitCode: number; stdout?: string; stderr?: string }> {
   const runtime = detectRuntime();
 
@@ -151,7 +155,7 @@ export async function spawn(
       Bun: {
         spawn: (
           command: string[],
-          options: { stdout?: string; stderr?: string }
+          options: { stdout?: string; stderr?: string; cwd?: string }
         ) => {
           exited: Promise<number>;
           stdout: { text: () => Promise<string> } | null;
@@ -163,6 +167,7 @@ export async function spawn(
     const proc = bunGlobal.Bun.spawn(command, {
       stdout: options.stdout ?? "pipe",
       stderr: options.stderr ?? "pipe",
+      ...(options.cwd ? { cwd: options.cwd } : {}),
     });
 
     const exitCode = await proc.exited;
@@ -182,6 +187,7 @@ export async function spawn(
           options.stdout === "inherit" ? "inherit" : "pipe",
           options.stderr === "inherit" ? "inherit" : "pipe",
         ],
+        ...(options.cwd ? { cwd: options.cwd } : {}),
       });
 
       let stdout = "";

--- a/tools/flow-think/tsconfig.json
+++ b/tools/flow-think/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "node16",
+    "moduleResolution": "node16",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -20,7 +20,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noEmit": false,
-    "types": ["bun-types", "node"]
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -571,34 +571,6 @@ install_codex() {
         fi
     done
 
-    # Install MCP configuration for flow-think server
-    local mcp_config_src="$TEMPLATES_DIR/codex/mcp-config.toml"
-    local config_dst="$CODEX_DIR/config.toml"
-
-    if [[ -f "$mcp_config_src" ]]; then
-        if [[ -f "$config_dst" ]]; then
-            if grep -q "mcp_servers.flow-think" "$config_dst" 2>/dev/null; then
-                log_info "MCP config: flow-think already configured"
-            else
-                # Backup existing config
-                backup_file "$config_dst"
-                # Append MCP configuration
-                echo "" >> "$config_dst"
-                echo "# --- Flow Framework MCP Configuration ---" >> "$config_dst"
-                cat "$mcp_config_src" >> "$config_dst"
-                # Replace placeholder with actual install path
-                sed -i "s|\${FLOW_INSTALL_PATH}|$SCRIPT_DIR|g" "$config_dst"
-                log_success "MCP config: Added flow-think server to config.toml"
-            fi
-        else
-            # Create new config with MCP settings
-            cp "$mcp_config_src" "$config_dst"
-            # Replace placeholder with actual install path
-            sed -i "s|\${FLOW_INSTALL_PATH}|$SCRIPT_DIR|g" "$config_dst"
-            log_success "MCP config: Created config.toml with flow-think server"
-        fi
-    fi
-
     echo ""
     log_success "Codex CLI installation complete"
 }
@@ -778,6 +750,8 @@ install_antigravity() {
 # MCP Installation
 # ─────────────────────────────────────────────────────────────────────────────
 
+MCP_INSTALL_TYPE=""  # "standalone" or "node" — set by install_mcp
+
 install_mcp() {
     echo ""
     echo -e "${CYAN}Installing Flow Think MCP Server...${NC}"
@@ -785,7 +759,8 @@ install_mcp() {
 
     local mcp_src="$SCRIPT_DIR/tools/flow-think"
     local mcp_dst="$FLOW_DATA_DIR/mcp/flow-think"
-    local mcp_exe="$mcp_src/dist/flow-think-mcp"
+    local mcp_standalone="$mcp_src/dist/flow-think-mcp"
+    local mcp_js="$mcp_src/dist/index.js"
 
     # Check if flow-think exists
     if [[ ! -d "$mcp_src" ]]; then
@@ -794,24 +769,22 @@ install_mcp() {
         return
     fi
 
-    # Build executable if it doesn't exist
-    if [[ ! -f "$mcp_exe" ]]; then
+    # Build if neither artifact exists
+    if [[ ! -f "$mcp_standalone" && ! -f "$mcp_js" ]]; then
         log_info "Building Flow Think MCP..."
         if command -v bun &>/dev/null; then
             (cd "$mcp_src" && bun install && ./scripts/build.sh) || {
-                log_error "Failed to build Flow Think MCP with bun"
+                log_error "Failed to build Flow Think MCP with Bun"
                 return
             }
-        elif command -v npm &>/dev/null && command -v tsc &>/dev/null; then
-            log_info "Bun not found, using npm and tsc fallback..."
+        elif command -v npm &>/dev/null; then
+            log_info "Bun not found, using npm + tsc fallback..."
             (cd "$mcp_src" && npm install && ./scripts/build.sh) || {
                 log_error "Failed to build Flow Think MCP with npm"
                 return
             }
-            # Fallback path outputs to index.js since compile isn't available
-            mcp_exe="$mcp_src/dist/index.js"
         else
-            log_error "Bun or (npm+tsc) required to build Flow Think MCP"
+            log_error "Bun or npm required to build Flow Think MCP"
             log_info "Install Bun: curl -fsSL https://bun.sh/install | bash"
             return
         fi
@@ -820,31 +793,54 @@ install_mcp() {
     # Create destination directory
     mkdir -p "$mcp_dst"
 
-    # Copy the built entrypoint
-    cp "$mcp_exe" "$mcp_dst/flow-think-mcp"
-    chmod +x "$mcp_dst/flow-think-mcp"
+    # Prefer standalone executable, fall back to JS bundle
+    if [[ -f "$mcp_standalone" ]]; then
+        MCP_INSTALL_TYPE="standalone"
+        cp "$mcp_standalone" "$mcp_dst/flow-think-mcp"
+        chmod +x "$mcp_dst/flow-think-mcp"
+        log_success "Flow Think MCP installed (standalone executable)"
+    elif [[ -f "$mcp_js" ]]; then
+        MCP_INSTALL_TYPE="node"
+        cp "$mcp_js" "$mcp_dst/index.js"
+        chmod +x "$mcp_dst/index.js"
+        log_success "Flow Think MCP installed (Node.js bundle)"
+    else
+        log_error "Build produced no usable artifact"
+        return
+    fi
 
-    echo ""
-    log_success "Flow Think MCP installed (standalone executable)"
-    log_info "Path: $mcp_dst/flow-think-mcp"
+    log_info "Path: $mcp_dst/"
+}
+
+# Returns the MCP command and args for the current install type.
+# Usage: get_mcp_command → sets MCP_CMD and MCP_ARGS
+get_mcp_command() {
+    local mcp_dst="$FLOW_DATA_DIR/mcp/flow-think"
+    if [[ "$MCP_INSTALL_TYPE" == "standalone" ]]; then
+        MCP_CMD="$mcp_dst/flow-think-mcp"
+        MCP_ARGS='[]'
+    else
+        MCP_CMD="node"
+        MCP_ARGS="[\"$mcp_dst/index.js\"]"
+    fi
 }
 
 configure_mcp_for_claude() {
     local claude_json="$HOME/.claude.json"
-    local mcp_exe="$FLOW_DATA_DIR/mcp/flow-think/flow-think-mcp"
 
-    log_info "Configuring MCP for Claude Code..."
-
-    # Check if standalone executable exists
-    if [[ ! -f "$mcp_exe" ]]; then
-        log_warn "Flow Think MCP executable not found at $mcp_exe"
-        log_info "Run install_mcp first"
+    if [[ -z "$MCP_INSTALL_TYPE" ]]; then
+        log_warn "MCP not installed — skipping Claude Code MCP config"
         return
     fi
 
-    local mcp_config='{
+    log_info "Configuring MCP for Claude Code..."
+    get_mcp_command
+
+    local mcp_config
+    if [[ "$MCP_INSTALL_TYPE" == "standalone" ]]; then
+        mcp_config='{
   "flow-think": {
-    "command": "'"$mcp_exe"'",
+    "command": "'"$MCP_CMD"'",
     "args": [],
     "env": {
       "FLOW_MCP_BEADS_SYNC": "true",
@@ -852,6 +848,18 @@ configure_mcp_for_claude() {
     }
   }
 }'
+    else
+        mcp_config='{
+  "flow-think": {
+    "command": "node",
+    "args": ["'"$FLOW_DATA_DIR/mcp/flow-think/index.js"'"],
+    "env": {
+      "FLOW_MCP_BEADS_SYNC": "true",
+      "FLOW_MCP_OUTPUT_FORMAT": "console"
+    }
+  }
+}'
+    fi
 
     if [[ -f "$claude_json" ]]; then
         backup_file "$claude_json"
@@ -862,9 +870,9 @@ configure_mcp_for_claude() {
             jq --argjson mcp "$mcp_config" '.mcpServers = (.mcpServers // {}) + $mcp' "$claude_json" > "$temp_file" && mv "$temp_file" "$claude_json"
             log_success "Merged: MCP configuration into ~/.claude.json"
         else
-            log_warn "jq not installed - manual MCP config required"
+            log_warn "jq not installed — manual MCP config required"
             echo "         Add to ~/.claude.json mcpServers:"
-            echo "         \"flow-think\": { \"command\": \"$mcp_exe\", \"args\": [] }"
+            echo "         \"flow-think\": { \"command\": \"$MCP_CMD\", \"args\": $MCP_ARGS }"
         fi
     else
         # Create new claude.json
@@ -872,21 +880,133 @@ configure_mcp_for_claude() {
             echo "{\"mcpServers\": $mcp_config}" | jq '.' > "$claude_json"
             log_success "Created: ~/.claude.json with MCP configuration"
         else
-            cat > "$claude_json" << EOF
-{
-  "mcpServers": {
-    "flow-think": {
-      "command": "$mcp_exe",
-      "args": [],
-      "env": {
-        "FLOW_MCP_BEADS_SYNC": "true"
-      }
-    }
-  }
-}
-EOF
+            echo "{\"mcpServers\": $mcp_config}" > "$claude_json"
             log_success "Created: ~/.claude.json with MCP configuration"
         fi
+    fi
+}
+
+configure_mcp_for_codex() {
+    local config_dst="$CODEX_DIR/config.toml"
+
+    if [[ -z "$MCP_INSTALL_TYPE" ]]; then
+        log_warn "MCP not installed — skipping Codex MCP config"
+        return
+    fi
+
+    log_info "Configuring MCP for Codex CLI..."
+    get_mcp_command
+
+    # Check if already configured
+    if [[ -f "$config_dst" ]] && grep -q "mcp_servers.flow-think" "$config_dst" 2>/dev/null; then
+        log_info "MCP config: flow-think already configured in config.toml"
+        return
+    fi
+
+    local toml_block
+    if [[ "$MCP_INSTALL_TYPE" == "standalone" ]]; then
+        toml_block=$(cat <<EOFTOML
+
+# --- Flow Framework MCP Configuration ---
+[mcp_servers.flow-think]
+command = "$MCP_CMD"
+args = []
+startup_timeout_sec = 15
+tool_timeout_sec = 120
+
+[mcp_servers.flow-think.env]
+FLOW_MCP_OUTPUT_FORMAT = "json"
+FLOW_MCP_BEADS_SYNC = "true"
+EOFTOML
+)
+    else
+        toml_block=$(cat <<EOFTOML
+
+# --- Flow Framework MCP Configuration ---
+[mcp_servers.flow-think]
+command = "node"
+args = ["$FLOW_DATA_DIR/mcp/flow-think/index.js"]
+startup_timeout_sec = 15
+tool_timeout_sec = 120
+
+[mcp_servers.flow-think.env]
+FLOW_MCP_OUTPUT_FORMAT = "json"
+FLOW_MCP_BEADS_SYNC = "true"
+EOFTOML
+)
+    fi
+
+    if [[ -f "$config_dst" ]]; then
+        backup_file "$config_dst"
+        echo "$toml_block" >> "$config_dst"
+        log_success "MCP config: Added flow-think server to config.toml"
+    else
+        mkdir -p "$(dirname "$config_dst")"
+        echo "$toml_block" > "$config_dst"
+        log_success "MCP config: Created config.toml with flow-think server"
+    fi
+}
+
+configure_mcp_for_opencode() {
+    local config_dst="$OPENCODE_DIR/config.json"
+
+    if [[ -z "$MCP_INSTALL_TYPE" ]]; then
+        log_warn "MCP not installed — skipping OpenCode MCP config"
+        return
+    fi
+
+    log_info "Configuring MCP for OpenCode..."
+    get_mcp_command
+
+    local mcp_json
+    if [[ "$MCP_INSTALL_TYPE" == "standalone" ]]; then
+        mcp_json='{
+      "command": "'"$MCP_CMD"'",
+      "args": [],
+      "env": {
+        "FLOW_MCP_BEADS_SYNC": "true",
+        "FLOW_MCP_OUTPUT_FORMAT": "console"
+      }
+    }'
+    else
+        mcp_json='{
+      "command": "node",
+      "args": ["'"$FLOW_DATA_DIR/mcp/flow-think/index.js"'"],
+      "env": {
+        "FLOW_MCP_BEADS_SYNC": "true",
+        "FLOW_MCP_OUTPUT_FORMAT": "console"
+      }
+    }'
+    fi
+
+    if [[ -f "$config_dst" ]]; then
+        if grep -q '"flow-think"' "$config_dst" 2>/dev/null; then
+            log_info "MCP config: flow-think already configured in OpenCode"
+            return
+        fi
+
+        backup_file "$config_dst"
+
+        if command -v jq &>/dev/null; then
+            local temp_file
+            temp_file=$(mktemp)
+            jq --argjson ft "$mcp_json" '.mcpServers["flow-think"] = $ft' "$config_dst" > "$temp_file" && mv "$temp_file" "$config_dst"
+            log_success "MCP config: Added flow-think to OpenCode config.json"
+        else
+            log_warn "jq not installed — add flow-think MCP config to $config_dst manually"
+            echo "         Key: mcpServers.flow-think"
+            echo "         Command: $MCP_CMD"
+        fi
+    else
+        mkdir -p "$(dirname "$config_dst")"
+        cat > "$config_dst" << EOFOPENCODE
+{
+  "mcpServers": {
+    "flow-think": $mcp_json
+  }
+}
+EOFOPENCODE
+        log_success "MCP config: Created OpenCode config.json with flow-think"
     fi
 }
 
@@ -1045,8 +1165,11 @@ main() {
     # Install MCP server
     install_mcp
 
-    # Configure MCP for Claude Code
+    # Configure MCP for each installed CLI
     $CLAUDE_INSTALLED && configure_mcp_for_claude
+    $CODEX_INSTALLED && configure_mcp_for_codex
+    $OPENCODE_INSTALLED && configure_mcp_for_opencode
+    # Gemini: configured via embedded gemini-extension.json
 
     # Check Beads
     check_beads


### PR DESCRIPTION
Update the version numbers for the flow and flow-think-mcp packages to v0.9.0. Enhance the spawn function for better subprocess handling and improve the installation script to ensure dependencies are installed correctly. Add runtime-aware configuration for the MCP server.