### PR TITLE
improve consensus skill description + inline workflow

### DIFF
--- a/skills/consensus/SKILL.md
+++ b/skills/consensus/SKILL.md
@@ -1,55 +1,71 @@
 ---
 name: consensus
-description: "Auto-activate when evaluating architectural decisions, comparing technology choices, weighing design trade-offs, assessing feature proposals, making build-vs-buy decisions, choosing between competing approaches, or when a decision has significant long-term consequences. Use when: decisions need structured multi-perspective analysis, risk assessment from multiple angles, or when the stakes are high enough to warrant deliberate evaluation."
+description: "Auto-activate when evaluating architectural decisions, comparing technology choices, weighing design trade-offs, assessing feature proposals, making build-vs-buy decisions, choosing between competing approaches, or when a decision has significant long-term consequences. Produces a structured recommendation with confidence level (low/medium/high), pro/con analysis, risk assessment, and concrete next steps. Use when: decisions need structured multi-perspective analysis, risk assessment from multiple angles, or when the stakes are high enough to warrant deliberate evaluation. Not for routine code review, simple config choices, or styling preferences."
 ---
 
 # Consensus
 
-Structured decision evaluation through stance rotation — analyze from advocate, critic, and neutral perspectives, then synthesize. References the `perspectives` skill for stance prompts and ethical guardrails.
+Structured decision evaluation through stance rotation — analyze from advocate, critic, and neutral perspectives, then synthesize into a confidence-rated recommendation with concrete next steps.
 
-## Overview
+## Workflow
 
-Evaluates decisions by rotating through three perspectives:
+### Step 1: Select Mode
 
-1. **Neutral** — objective analysis of all factors
-2. **Advocate** — strongest case FOR (with ethical guardrails)
-3. **Critic** — rigorous scrutiny of risks (with ethical guardrails)
-4. **Synthesis** — weigh all three, produce recommendation with confidence level
+| Decision Scope | Mode | Reason |
+| -------------- | ---- | ------ |
+| Bounded, reversible | **Sequential** (default) | All perspectives in one pass — fast |
+| Multi-month or irreversible | **Subagent** | Three isolated subagents prevent cross-contamination |
+| Perspectives suspiciously aligned | Escalate to **Subagent** | Lack of genuine disagreement signals contamination |
 
-Two modes based on decision complexity:
-- **Sequential** (default) — all perspectives in one pass, fast
-- **Subagent** — three isolated subagents for true independence, used for high-stakes decisions
+See `references/consensus-strategy.md` for full escalation criteria.
 
-## Usage Patterns
+### Step 2: Stance Rotation
 
-- "Should we migrate from REST to GraphQL?"
-- "Evaluate this architecture proposal"
-- "Is this the right database choice for our use case?"
-- "Weigh the trade-offs of splitting this into microservices"
-- "I need a thorough analysis of whether to rewrite vs refactor"
+Rotate through three perspectives (see `references/stance-rotation.md` for detailed prompts):
 
-## How It Works
+1. **Neutral** — state the decision, list all factors (technical, organizational, timeline, risk), note missing information, present assessment without leaning toward a conclusion.
+2. **Advocate** — build the strongest case FOR: what problems does it solve, what synergies does it create, how can challenges be overcome? Subject to ethical guardrails — refuse to advocate if fundamentally harmful.
+3. **Critic** — rigorous scrutiny: real risks, overlooked complexities, simpler alternatives, flawed assumptions? Subject to ethical guardrails — acknowledge if the proposal is genuinely sound.
 
-### Mode Selection
+In **subagent mode**, dispatch three isolated subagents (one per stance) with identical context. Subagents must NOT see each other's output.
 
-Follow `references/consensus-strategy.md` to choose:
-- **Sequential mode** — bounded scope, clear constraints, time pressure
-- **Subagent mode** — affects >3 months of work, irreversible, perspectives suspiciously aligned
+### Step 3: Synthesize
 
-### Stance Rotation
+Weigh all three perspectives and produce a recommendation:
 
-Follow `references/stance-rotation.md` for the rotation steps and synthesis framework.
+1. **Points of agreement** — where all perspectives align (strong signal)
+2. **Points of disagreement** — where they diverge and why
+3. **Recommendation** — with confidence level: **low** / **medium** / **high**
+4. **Would change if** — conditions that would flip the recommendation
+5. **Next steps** — concrete actions based on the recommendation
 
-### Decision Scope Guide
+### Validation Checkpoint
 
-| Decision Scope | Recommended Mode |
-| -------------- | ---------------- |
-| Bounded, reversible | Sequential |
-| Multi-month, irreversible | Subagent |
-| Perspectives suspiciously aligned | Escalate to subagent |
+Before delivering the synthesis, verify:
+- [ ] Each perspective contributed at least one unique point not raised by the others
+- [ ] The critic identified at least one genuine risk (not manufactured disagreement)
+- [ ] The recommendation confidence level is justified by the degree of inter-perspective agreement
+- [ ] If all three perspectives agree too easily, escalate to subagent mode
 
-## References Index
+## Example
+
+**Decision:** "Should we migrate from REST to GraphQL?"
+
+| Perspective | Key Finding |
+|-------------|-------------|
+| Neutral | Current REST API has 47 endpoints; clients use ad-hoc field filtering. GraphQL would reduce over-fetching but adds schema maintenance. |
+| Advocate | Mobile clients would cut payload size ~60%. Single endpoint simplifies versioning. Strong ecosystem tooling available. |
+| Critic | Team has no GraphQL experience — 2-3 month learning curve. Caching is harder. Existing REST clients need migration path. |
+
+**Synthesis:**
+- Agreement: Current API has over-fetching problems worth solving.
+- Disagreement: Whether the learning curve cost is justified given timeline.
+- Recommendation: **Adopt GraphQL for new endpoints only** (confidence: **medium**).
+- Would change if: Team had prior GraphQL experience (→ high confidence, full migration) or deadline is <3 months (→ stay REST).
+- Next steps: 1) Prototype one high-traffic endpoint. 2) Measure payload reduction. 3) Decide on full migration after prototype.
+
+## References
 
 - **[Consensus Strategy](references/consensus-strategy.md)** — Mode selection and escalation criteria
-- **[Stance Rotation](references/stance-rotation.md)** — Rotation steps, subagent dispatch, synthesis framework
-- **[Stance Prompts](../perspectives/references/stances.md)** — Advocate, critic, neutral prompts (from perspectives skill)
+- **[Stance Rotation](references/stance-rotation.md)** — Detailed rotation steps, subagent dispatch, synthesis framework
+- **[Stance Prompts](../perspectives/references/stances.md)** — Advocate, critic, neutral prompts with ethical guardrails (from perspectives skill)


### PR DESCRIPTION
hey @cofin, thanks for building flow. really like the "measure twice, code once" philosophy + the breadth of 55 technology-specific skills. kudos for the repo! just starred it.

ran your consensus skill through some evals and noticed a few things that were pretty quick to improve (moving from `~69%` to `~94%` agent performance):

- expanded description with concrete outputs (confidence level, pro/con analysis, risk assessment) + explicit exclusions so agents know when not to use it.
- inlined the stance rotation steps + synthesis framework directly instead of fully deferring to references.
- added a validation checkpoint with escalation feedback loop + a concrete REST-to-GraphQL migration example.

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `55` skills, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.