### PR TITLE
fix(install): fix sed portability and improve beads detection prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "flow",
       "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "source": "./",
       "author": {
         "name": "cofin"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "cofin"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
   "author": { "name": "cofin" },
   "homepage": "https://github.com/cofin/flow",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "cofin"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,11 +146,18 @@ Use `choosing-beads-backend` for exact command mapping and migration guidance.
 ### Installation Check
 
 ```bash
-command -v bd >/dev/null 2>&1 && echo "BD_OK" || \
-command -v br >/dev/null 2>&1 && echo "BR_OK" || \
-echo "BEADS_MISSING"
+if command -v bd >/dev/null 2>&1 && command -v br >/dev/null 2>&1; then
+  echo "BEADS_BOTH"
+elif command -v bd >/dev/null 2>&1; then
+  echo "BD_OK"
+elif command -v br >/dev/null 2>&1; then
+  echo "BR_OK"
+else
+  echo "BEADS_MISSING"
+fi
 ```
 
+If `BEADS_BOTH` is found, Flow should offer a choice between `bd` and `br`.
 If missing, Flow should offer a concise menu:
 
 - **A) Install official Beads (`bd`)** (recommended)

--- a/commands/flow-setup.md
+++ b/commands/flow-setup.md
@@ -51,7 +51,11 @@ fi
 ### 0.1.1 Beads Validation
 
 ```bash
-if command -v bd >/dev/null 2>&1; then
+if command -v bd >/dev/null 2>&1 && command -v br >/dev/null 2>&1; then
+  echo "BEADS_BOTH"
+  bd --version
+  br version
+elif command -v bd >/dev/null 2>&1; then
   echo "BEADS_BD"
   bd --version
 elif command -v br >/dev/null 2>&1; then
@@ -61,6 +65,13 @@ else
   echo "BEADS_MISSING"
 fi
 ```
+
+If `BEADS_BOTH` is found, ask user:
+
+> **Both official Beads (bd) and beads_rust (br) detected. Which would you like to use for Flow projects?**
+>
+> - **A) Official Beads (bd)** (recommended)
+> - **B) beads_rust compatibility (br)**
 
 If outdated, suggest the official install first: `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`
 Compatibility fallback: `curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash`
@@ -210,7 +221,9 @@ Run `/flow-status` to see current state.
 **CRITICAL: Prefer official Beads, but Flow can also run with `br` compatibility mode or no-Beads mode.**
 
 ```bash
-if command -v bd >/dev/null 2>&1; then
+if command -v bd >/dev/null 2>&1 && command -v br >/dev/null 2>&1; then
+  echo "BEADS_BOTH"
+elif command -v bd >/dev/null 2>&1; then
   echo "BEADS_BD"
 elif command -v br >/dev/null 2>&1; then
   echo "BEADS_BR"
@@ -218,6 +231,13 @@ else
   echo "BEADS_MISSING"
 fi
 ```
+
+If `BEADS_BOTH` is found, ask user:
+
+> **Both official Beads (bd) and beads_rust (br) detected. Which would you like to use?**
+>
+> - **A) Official Beads (bd)** (recommended)
+> - **B) beads_rust compatibility (br)**
 
 If no backend is found, ask user:
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "contextFileName": "GEMINI.md",
   "plan": {
     "directory": ".agents/specs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Unified toolkit for Context-Driven Development",
   "type": "module",
   "main": ".opencode/plugins/flow.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow"
-version = "0.15.0"
+version = "0.15.1"
 description = "Unified toolkit for Context-Driven Development"
 authors = [
   { name = "cofin" },
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.15.0"
+current_version = "0.15.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/skills/flow/references/setup.md
+++ b/skills/flow/references/setup.md
@@ -123,10 +123,18 @@ Run `flow-status` to see current state.
 **CRITICAL:** Prefer official Beads, but do not force unnecessary admin work.
 
 ```bash
-command -v bd >/dev/null 2>&1 && echo "BD_OK" || \
-command -v br >/dev/null 2>&1 && echo "BR_OK" || \
-echo "BEADS_MISSING"
+if command -v bd >/dev/null 2>&1 && command -v br >/dev/null 2>&1; then
+  echo "BEADS_BOTH"
+elif command -v bd >/dev/null 2>&1; then
+  echo "BD_OK"
+elif command -v br >/dev/null 2>&1; then
+  echo "BR_OK"
+else
+  echo "BEADS_MISSING"
+fi
 ```
+
+If `BEADS_BOTH` is found, ask user to choose between `bd` and `br`.
 
 If no backend is found, ask user:
 

--- a/templates/opencode/commands/flow-setup.md
+++ b/templates/opencode/commands/flow-setup.md
@@ -50,7 +50,11 @@ fi
 ### 0.1.1 Beads Validation
 
 ```bash
-if command -v bd >/dev/null 2>&1; then
+if command -v bd >/dev/null 2>&1 && command -v br >/dev/null 2>&1; then
+  echo "BEADS_BOTH"
+  bd --version
+  br version
+elif command -v bd >/dev/null 2>&1; then
   echo "BEADS_BD"
   bd --version
 elif command -v br >/dev/null 2>&1; then
@@ -60,6 +64,8 @@ else
   echo "BEADS_MISSING"
 fi
 ```
+
+If `BEADS_BOTH` is found, ask user to choose between `bd` and `br` for Flow projects.
 
 If outdated, suggest the official install first: `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`
 Compatibility fallback: `curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh | bash`
@@ -133,7 +139,9 @@ Run `/flow-status` to see current state.
 **CRITICAL: Prefer official Beads, but Flow can also run with `br` compatibility mode or no-Beads mode.**
 
 ```bash
-if command -v bd >/dev/null 2>&1; then
+if command -v bd >/dev/null 2>&1 && command -v br >/dev/null 2>&1; then
+  echo "BEADS_BOTH"
+elif command -v bd >/dev/null 2>&1; then
   echo "BEADS_BD"
 elif command -v br >/dev/null 2>&1; then
   echo "BEADS_BR"
@@ -141,6 +149,8 @@ else
   echo "BEADS_MISSING"
 fi
 ```
+
+If `BEADS_BOTH` is found, ask user to choose between `bd` and `br`.
 
 If no backend is found, ask user:
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -213,8 +213,14 @@ cleanup_codex_legacy() {
     # Remove Flow section from old AGENTS.md
     if [[ -f "$CODEX_DIR/AGENTS.md" ]] && grep -q "Flow Framework" "$CODEX_DIR/AGENTS.md" 2>/dev/null; then
         backup_file "$CODEX_DIR/AGENTS.md"
-        sed -i '/^# Flow Framework/,$d' "$CODEX_DIR/AGENTS.md"
-        sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$CODEX_DIR/AGENTS.md"
+        local agents_file="$CODEX_DIR/AGENTS.md"
+        local tmp_file=$(mktemp)
+        sed '/^# Flow Framework/,$d' "$agents_file" > "$tmp_file"
+        mv "$tmp_file" "$agents_file"
+        
+        tmp_file=$(mktemp)
+        sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$agents_file" > "$tmp_file"
+        mv "$tmp_file" "$agents_file"
         log_success "Removed legacy Flow section from AGENTS.md"
         cleaned=true
     fi
@@ -672,15 +678,45 @@ check_beads() {
     echo -e "${CYAN}Checking Beads CLI...${NC}"
     echo ""
 
+    local bd_installed=false
+    local br_installed=false
+
     if command -v bd &> /dev/null; then
+        bd_installed=true
+    fi
+
+    if command -v br &> /dev/null; then
+        br_installed=true
+    fi
+
+    if $bd_installed && $br_installed; then
+        log_success "Both official Beads (bd) and beads_rust (br) detected"
+        echo ""
+        echo "Which would you like to use for Flow projects by default?"
+        echo "  1) Official Beads (bd) (recommended)"
+        echo "  2) beads_rust compatibility (br)"
+        echo ""
+        read -p "Select [1-2]: " -n 1 -r
+        echo
+        case $REPLY in
+            1) 
+                log_info "Flow setup will default to: bd init --stealth --prefix <repo-slug>"
+                ;;
+            2) 
+                log_info "Flow setup will default to: br init --prefix <repo-slug>"
+                ;;
+            *)
+                log_info "No selection made; defaulting to: bd init --stealth --prefix <repo-slug>"
+                ;;
+        esac
+        return
+    elif $bd_installed; then
         local version
         version=$(bd --version 2>/dev/null || echo "unknown")
         log_success "Official Beads (bd) installed: $version"
         log_info "Flow setup will default to: bd init --stealth --prefix <repo-slug>"
         return
-    fi
-
-    if command -v br &> /dev/null; then
+    elif $br_installed; then
         local version
         version=$(br --version 2>/dev/null || echo "unknown")
         log_success "beads_rust compatibility (br) installed: $version"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -48,7 +48,7 @@ show_banner() {
     echo -e "${CYAN}"
     echo "╔══════════════════════════════════════════════════════════════╗"
     echo "║             Flow Framework - Plugin Installer                ║"
-    echo "║                       Version 0.15.0                         ║"
+    echo "║                       Version 0.15.1                         ║"
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo -e "${NC}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "flow"
-version = "0.14.1"
+version = "0.15.0"
 source = { virtual = "." }


### PR DESCRIPTION
## Summary
This pull request addresses two key areas:
1. **Portable  Usage**: Replaced non-portable `sed -i` with a portable redirect + rename pattern using `mktemp`. This resolves the error on macOS/BSD where `sed -i` requires an extension argument.
2. **Improved Beads Detection**: Enhanced the Beads CLI detection logic. If both `bd` (Official Beads) and `br` (`beads_rust`) are detected, Flow now prompts the user to choose their preferred backend instead of automatically defaulting.

## Changes
- **tools/install.sh**: Fixed `sed` calls and added choice prompt for Beads detection.
- **commands/flow-setup.md**: Updated Phase 1 and Alignment Mode to handle multiple backends.
- **AGENTS.md**: Updated Installation Check section.
- **skills/flow/references/setup.md**: Updated skill documentation.
- **templates/opencode/commands/flow-setup.md**: Updated OpenCode setup template.