### PR TITLE
feature: remove redundant manifest hook reference and ignore .agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "flow",
       "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "source": "./",
       "author": {
         "name": "cofin"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "author": {
     "name": "cofin"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,6 +11,5 @@
   "license": "MIT",
   "keywords": ["flow", "context-driven-development", "beads", "tdd", "ai-agent", "workflow", "spec-first"],
   "skills": "./skills/",
-  "commands": "./commands/",
-  "hooks": "./hooks/hooks.json"
+  "commands": "./commands/"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
   "author": { "name": "cofin" },
   "homepage": "https://github.com/cofin/flow",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "author": {
     "name": "cofin"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ windsurf.mcp.json
 .beads-credential-key
 .worktrees/
 .agents/
+.beads/

--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,9 @@ gemini.mcp.json
 cline.mcp.json
 cursor.mcp.json
 windsurf.mcp.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ windsurf.mcp.json
 *.db
 .beads-credential-key
 .worktrees/
+.agents/

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "contextFileName": "GEMINI.md",
   "plan": {
     "directory": ".agents/specs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Unified toolkit for Context-Driven Development",
   "type": "module",
   "main": ".opencode/plugins/flow.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow"
-version = "0.15.1"
+version = "0.15.2"
 description = "Unified toolkit for Context-Driven Development"
 authors = [
   { name = "cofin" },
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.15.1"
+current_version = "0.15.2"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -48,7 +48,7 @@ show_banner() {
     echo -e "${CYAN}"
     echo "╔══════════════════════════════════════════════════════════════╗"
     echo "║             Flow Framework - Plugin Installer                ║"
-    echo "║                       Version 0.15.1                         ║"
+    echo "║                       Version 0.15.2                         ║"
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo -e "${NC}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "flow"
-version = "0.15.0"
+version = "0.15.1"
 source = { virtual = "." }


### PR DESCRIPTION
## Changes
- Remove redundant 'hooks' field from `.claude-plugin/plugin.json` to resolve duplicate hook loading error.
- Add `.agents/` to `.gitignore` to ensure context files remain project-local. 