### PR TITLE
fix(hooks): properly escape backticks and quotes in session-start hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "flow",
       "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "source": "./",
       "author": {
         "name": "cofin"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "author": {
     "name": "cofin"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
   "author": { "name": "cofin" },
   "homepage": "https://github.com/cofin/flow",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "author": {
     "name": "cofin"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "contextFileName": "GEMINI.md",
   "plan": {
     "directory": ".agents/specs"

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -21,6 +21,7 @@ escape_for_json() {
 }
 
 # Build session context with auto-trigger rules and spec dir override
+# Quoting characters are escaped with \ to be safe in double-quoted bash string
 session_context="You have the Flow framework installed.
 
 Flow provides Context-Driven Development with spec-first planning, TDD workflow, and Beads integration for cross-session memory.
@@ -34,8 +35,8 @@ AUTO-TRIGGER RULES:
 - When user mentions \"beads\", \"bd\", \"br\", or backend migration: invoke 'flow' skill
 - When a spec or PRD exists but task detail is coarse: invoke 'flow-refine' before implementation or subagent dispatch
 - When PRD/planning work appears complete: run a research-closure pass and do not stop while obvious research gaps remain
-- Read `.agents/workflow.md` early and prefer the repo's canonical commands such as `make lint`, `make test`, `make check`, `just check`, `task test`, package scripts, or pre-commit wrappers when they exist
-- If an existing install is detected, offer a workflow refresh/revalidation pass instead of assuming `workflow.md` is current
+- Read \`.agents/workflow.md\` early and prefer the repo's canonical commands such as \`make lint\`, \`make test\`, \`make check\`, \`just check\`, \`task test\`, package scripts, or pre-commit wrappers when they exist
+- If an existing install is detected, offer a workflow refresh/revalidation pass instead of assuming \`workflow.md\` is current
 - Never silently descope when the task is larger than expected; refine the plan or ask the user how to prioritize
 - Be collaborative and constructive. Never use dismissive ownership-deflecting language such as \"not my issue\" or \"not caused by my change\"
 - Make minimal targeted changes and avoid unrelated opportunistic edits without approval
@@ -50,9 +51,9 @@ When using superpowers brainstorming or writing specs/designs, you MUST write al
 MANDATORY SUPERPOWERS INTEGRATION:
 - All implementation plans MUST be written to .agents/specs/<flow_id>/spec.md.
 - Planning and PRD work MUST use brainstorming, then refine coarse task details before implementation.
-- When implement is requested, you MUST recommend "Subagent-Driven" approach if superpowers:subagent-driven-development is available.
+- When implement is requested, you MUST recommend \"Subagent-Driven\" approach if superpowers:subagent-driven-development is available.
 - Before dispatching a subagent, preserve context by passing the relevant spec/PRD, patterns, knowledge chapters, learnings, affected files, and verification requirements.
-- PRDs and Plans MUST undergo a "Self-Review" using code-reviewer or similar quality gate skills before finalization.
+- PRDs and Plans MUST undergo a \"Self-Review\" using code-reviewer or similar quality gate skills before finalization.
 - TDD and Verification before completion are REQUIRED for all implementation tasks.
 
 Use the Skill tool to invoke Flow skills. Key skills:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Unified toolkit for Context-Driven Development",
   "type": "module",
   "main": ".opencode/plugins/flow.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow"
-version = "0.15.2"
+version = "0.15.3"
 description = "Unified toolkit for Context-Driven Development"
 authors = [
   { name = "cofin" },
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.15.2"
+current_version = "0.15.3"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -48,7 +48,7 @@ show_banner() {
     echo -e "${CYAN}"
     echo "╔══════════════════════════════════════════════════════════════╗"
     echo "║             Flow Framework - Plugin Installer                ║"
-    echo "║                       Version 0.15.2                         ║"
+    echo "║                       Version 0.15.3                         ║"
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo -e "${NC}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "flow"
-version = "0.15.1"
+version = "0.15.2"
 source = { virtual = "." }


### PR DESCRIPTION
This PR fixes a startup hook error where unescaped backticks in the `session-start` hook were causing Bash to perform command substitution (attempting to execute `.agents/workflow.md`).

Changes:
- Properly escape backticks and double quotes in the `session_context` string within `hooks/session-start`.
- Bump version to 0.15.3 across all plugin files and installer script.
- The hook now gracefully handles missing `.agents` directory as it no longer attempts to access files directly during initialization.