### PR TITLE
fix: plugin hook loading across hosts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,6 +11,5 @@
   "license": "MIT",
   "keywords": ["flow", "context-driven-development", "beads", "tdd", "ai-agent", "workflow", "spec-first", "skills", "slash-commands", "subagents"],
   "skills": ["./skills/"],
-  "commands": ["./commands/"],
-  "hooks": "./hooks/hooks-claude.json"
+  "commands": ["./commands/"]
 }

--- a/hooks/hooks-claude.json
+++ b/hooks/hooks-claude.json
@@ -1,15 +1,17 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "name": "flow-env-detection",
-          "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
-          "description": "Detects Beads backend and project root at session start."
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "flow-env-detection",
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
+            "description": "Detects Beads backend and project root at session start."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,15 +1,17 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "name": "flow-env-detection",
-          "type": "command",
-          "command": "${extensionPath}/hooks/session-start",
-          "description": "Detects Beads backend and project root at session start."
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "flow-env-detection",
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT:-${extensionPath}}/hooks/session-start",
+            "description": "Detects Beads backend and project root at session start."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/tests/test_gemini_hooks.py
+++ b/tests/test_gemini_hooks.py
@@ -12,25 +12,33 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def test_gemini_extension_session_start_hook_uses_extension_path() -> None:
     hooks = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
 
-    command = hooks["SessionStart"][0]["hooks"][0]["command"]
+    command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
 
-    assert command == "${extensionPath}/hooks/session-start"
-    assert "${CLAUDE_PLUGIN_ROOT}" not in command
+    assert command == "${CLAUDE_PLUGIN_ROOT:-${extensionPath}}/hooks/session-start"
+    assert "${extensionPath}" in command
+    assert "${CLAUDE_PLUGIN_ROOT:-" in command
 
 
-def test_claude_plugin_references_claude_specific_hook_config() -> None:
+def test_claude_plugin_relies_on_auto_discovered_root_hook_config() -> None:
     plugin = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
 
-    assert plugin["hooks"] == "./hooks/hooks-claude.json"
+    assert "hooks" not in plugin
 
 
-def test_claude_hook_manifest_uses_claude_plugin_root() -> None:
-    hooks = json.loads((REPO_ROOT / "hooks" / "hooks-claude.json").read_text(encoding="utf-8"))
+def test_shared_hook_manifest_supports_claude_runtime_resolution() -> None:
+    hooks = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
 
-    command = hooks["SessionStart"][0]["hooks"][0]["command"]
+    command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
 
-    assert command == "${CLAUDE_PLUGIN_ROOT}/hooks/session-start"
-    assert "${extensionPath}" not in command
+    assert command.startswith("${CLAUDE_PLUGIN_ROOT:-")
+    assert command.endswith("}/hooks/session-start")
+
+
+def test_shared_hook_manifest_uses_top_level_hooks_record() -> None:
+    gemini_hooks = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+
+    assert "hooks" in gemini_hooks
+    assert "SessionStart" in gemini_hooks["hooks"]
 
 
 def test_session_start_emits_claude_compatible_payload_when_claude_env_present() -> None:

--- a/tests/test_validate_skills.py
+++ b/tests/test_validate_skills.py
@@ -69,17 +69,19 @@ def test_claude_hook_config_rejects_cursor_placeholder(tmp_path: Path) -> None:
     _write_json(
         hooks_path,
         {
-            "SessionStart": [
-                {
-                    "matcher": "*",
-                    "hooks": [
-                        {
-                            "type": "command",
-                            "command": "${extensionPath}/hooks/session-start",
-                        }
-                    ],
-                }
-            ]
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${extensionPath}/hooks/session-start",
+                            }
+                        ],
+                    }
+                ]
+            }
         },
     )
 
@@ -103,6 +105,33 @@ def test_claude_manifest_accepts_valid_string_hooks_path(tmp_path: Path) -> None
     _write_json(
         tmp_path / "hooks" / "hooks-claude.json",
         {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+
+    violations = validate_skills.validate_manifest(tmp_path / ".claude-plugin" / "plugin.json")
+    violations.extend(validate_skills.validate_claude_hook_config(tmp_path / "hooks" / "hooks-claude.json"))
+
+    assert violations == []
+
+
+def test_hook_config_requires_top_level_hooks_record(tmp_path: Path) -> None:
+    hooks_path = tmp_path / "hooks" / "hooks-claude.json"
+    _write_json(
+        hooks_path,
+        {
             "SessionStart": [
                 {
                     "matcher": "*",
@@ -117,14 +146,64 @@ def test_claude_manifest_accepts_valid_string_hooks_path(tmp_path: Path) -> None
         },
     )
 
-    violations = validate_skills.validate_manifest(tmp_path / ".claude-plugin" / "plugin.json")
-    violations.extend(validate_skills.validate_claude_hook_config(tmp_path / "hooks" / "hooks-claude.json"))
+    violations = validate_skills.validate_claude_hook_config(hooks_path)
 
-    assert violations == []
+    assert any("top-level 'hooks' record" in violation.message for violation in violations)
+
+
+def test_gemini_hook_config_rejects_claude_placeholder(tmp_path: Path) -> None:
+    hooks_path = tmp_path / "hooks" / "hooks.json"
+    _write_json(
+        hooks_path,
+        {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+
+    violations = validate_skills.validate_gemini_hook_config(hooks_path)
+
+    assert any("${CLAUDE_PLUGIN_ROOT}" in violation.message for violation in violations)
 
 
 def test_repo_claude_hook_discovery_targets_claude_specific_config() -> None:
-    assert list(validate_skills.iter_claude_hook_configs()) == [REPO_ROOT / "hooks" / "hooks-claude.json"]
+    assert list(validate_skills.iter_claude_hook_configs()) == [REPO_ROOT / "hooks" / "hooks.json"]
+
+
+def test_shared_hook_config_allows_cross_host_fallback_command(tmp_path: Path) -> None:
+    hooks_path = tmp_path / "hooks" / "hooks.json"
+    _write_json(
+        hooks_path,
+        {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${CLAUDE_PLUGIN_ROOT:-${extensionPath}}/hooks/session-start",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+
+    assert validate_skills.validate_claude_hook_config(hooks_path) == []
+    assert validate_skills.validate_gemini_hook_config(hooks_path) == []
 
 
 def test_repo_cursor_and_codex_manifests_still_validate() -> None:

--- a/tools/validate-skills.py
+++ b/tools/validate-skills.py
@@ -165,6 +165,7 @@ VALID_GEMINI_TOOLS = frozenset(
 )
 _GEMINI_WILDCARD_PATTERN = re.compile(r"^(?:\*|mcp_[A-Za-z0-9_-]*\*?)$")
 _CLAUDE_HOOK_EVENT_PATTERN = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+_CROSS_HOST_HOOK_FALLBACK = "${CLAUDE_PLUGIN_ROOT:-${extensionPath}}"
 
 # Codex nickname_candidates entries: ASCII letters, digits, spaces, hyphens,
 # underscores only. Per https://developers.openai.com/codex/subagents.
@@ -228,10 +229,10 @@ def _validate_manifest_path_list_field(path: Path, field: str, value: object) ->
     return violations
 
 
-def _validate_claude_inline_hooks(path: Path, hooks: object) -> list[Violation]:
+def _validate_hook_event_map(path: Path, hooks: object) -> list[Violation]:
     violations: list[Violation] = []
     if not isinstance(hooks, dict):
-        return [Violation(path, 1, "Claude manifest 'hooks' field must be a string path or inline PascalCase hook object")]
+        return [Violation(path, 1, "hook config must contain a top-level 'hooks' record")]
     for event_name, matchers in hooks.items():
         if not isinstance(event_name, str) or not _CLAUDE_HOOK_EVENT_PATTERN.match(event_name):
             violations.append(Violation(path, 1, f"Claude hooks event {event_name!r} must be PascalCase"))
@@ -279,23 +280,60 @@ def _iter_nested_strings(value: object) -> Iterator[str]:
             yield from _iter_nested_strings(nested)
 
 
-def validate_claude_hook_config(path: Path) -> list[Violation]:
-    """Validate Claude's hook config file for host-specific placeholder usage."""
+def _load_hook_event_map(path: Path) -> tuple[dict[str, object] | None, list[Violation]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
-        return [Violation(path, 1, f"JSON parse error: {exc}")]
+        return None, [Violation(path, 1, f"JSON parse error: {exc}")]
 
-    for entry in _iter_nested_strings(data):
-        if "${extensionPath}" in entry:
-            return [
+    if not isinstance(data, dict):
+        return None, [Violation(path, 1, "hook config must be a JSON object")]
+
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return None, [Violation(path, 1, "hook config must contain a top-level 'hooks' record")]
+
+    return cast("dict[str, object]", hooks), []
+
+
+def validate_claude_hook_config(path: Path) -> list[Violation]:
+    """Validate Claude's hook config file for host-specific placeholder usage."""
+    hook_events, violations = _load_hook_event_map(path)
+    if hook_events is None:
+        return violations
+
+    violations.extend(_validate_hook_event_map(path, hook_events))
+    for entry in _iter_nested_strings(hook_events):
+        if "${extensionPath}" in entry and _CROSS_HOST_HOOK_FALLBACK not in entry:
+            violations.append(
                 Violation(
                     path,
                     1,
                     "Claude hook config must not use '${extensionPath}'; use '${CLAUDE_PLUGIN_ROOT}' instead",
                 )
-            ]
-    return []
+            )
+            break
+    return violations
+
+
+def validate_gemini_hook_config(path: Path) -> list[Violation]:
+    """Validate Gemini's hook config file for host-specific placeholder usage."""
+    hook_events, violations = _load_hook_event_map(path)
+    if hook_events is None:
+        return violations
+
+    violations.extend(_validate_hook_event_map(path, hook_events))
+    for entry in _iter_nested_strings(hook_events):
+        if "${CLAUDE_PLUGIN_ROOT}" in entry and _CROSS_HOST_HOOK_FALLBACK not in entry:
+            violations.append(
+                Violation(
+                    path,
+                    1,
+                    "Gemini hook config must not use '${CLAUDE_PLUGIN_ROOT}'; use '${extensionPath}' instead",
+                )
+            )
+            break
+    return violations
 
 
 def extract_frontmatter(text: str) -> tuple[dict[str, Any], int, str]:
@@ -543,7 +581,7 @@ def validate_manifest(path: Path) -> list[Violation]:
         if isinstance(hooks, str):
             violations.extend(_validate_manifest_path_field(path, "hooks", hooks))
         elif hooks is not None:
-            violations.extend(_validate_claude_inline_hooks(path, hooks))
+            violations.extend(_validate_hook_event_map(path, hooks))
     else:
         for field in ("skills", "commands", "hooks"):
             value = data.get(field)
@@ -720,6 +758,12 @@ def iter_manifests() -> Iterator[Path]:
 
 
 def iter_claude_hook_configs() -> Iterator[Path]:
+    default_hooks = REPO_ROOT / "hooks" / "hooks.json"
+    seen: set[Path] = set()
+    if default_hooks.is_file():
+        seen.add(default_hooks.resolve())
+        yield default_hooks
+
     manifest_path = REPO_ROOT / ".claude-plugin" / "plugin.json"
     if not manifest_path.is_file():
         return
@@ -733,8 +777,14 @@ def iter_claude_hook_configs() -> Iterator[Path]:
         return
 
     resolved, error = _resolve_plugin_path(manifest_path, hooks)
-    if error is None and resolved is not None and resolved.is_file():
+    if error is None and resolved is not None and resolved.is_file() and resolved not in seen:
         yield resolved
+
+
+def iter_gemini_hook_configs() -> Iterator[Path]:
+    candidate = REPO_ROOT / "hooks" / "hooks.json"
+    if candidate.is_file():
+        yield candidate
 
 
 def iter_all_shipped_files() -> Iterator[Path]:
@@ -787,6 +837,7 @@ def main() -> int:
     codex_agents = list(iter_codex_agents())
     manifests = list(iter_manifests())
     claude_hook_configs = list(iter_claude_hook_configs())
+    gemini_hook_configs = list(iter_gemini_hook_configs())
     for manifest_path in manifests:
         all_violations.extend(validate_manifest(manifest_path))
     for skill_path in skills:
@@ -803,6 +854,8 @@ def main() -> int:
         all_violations.extend(validate_codex_agent(agent_path))
     for hook_config_path in claude_hook_configs:
         all_violations.extend(validate_claude_hook_config(hook_config_path))
+    for hook_config_path in gemini_hook_configs:
+        all_violations.extend(validate_gemini_hook_config(hook_config_path))
     shipped = list(iter_all_shipped_files())
     all_violations.extend(check_agents_leak(shipped))
     all_violations.extend(check_forbidden_vocab(shipped))


### PR DESCRIPTION
## Summary
Fix Flow's plugin hook configuration so the same root `hooks/hooks.json` loads correctly in Claude and Gemini.

## What changed
- switched the shared hook config to the current schema with a top-level `hooks` record
- restored Claude to its normal auto-discovered root hook file instead of a Claude-only override in `.claude-plugin/plugin.json`
- updated the shared hook command to resolve under Claude with `${CLAUDE_PLUGIN_ROOT}` and under Gemini with `${extensionPath}`
- tightened `tools/validate-skills.py` so hook schema and host-specific placeholder mistakes are caught in CI
- added regression coverage for the shared hook file, Claude auto-discovery, and the cross-host fallback command

## Root cause
Two separate issues were colliding:
- Claude 2.1.114 expects hook files to contain a top-level `hooks` object and auto-discovers `hooks/hooks.json`
- Gemini still expects `${extensionPath}` in extension hook files, while Claude expects `${CLAUDE_PLUGIN_ROOT}`
 
