### PR TITLE
fix(plugin): valid userConfig schema and wire useBeads/agentsDir into hooks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "flow",
-  "displayName": "Flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
   "version": "0.20.0",
   "author": {
@@ -14,14 +13,15 @@
   "commands": ["./commands/"],
   "hooks": "./hooks/hooks-claude.json",
   "userConfig": {
-    "beadsBackend": {
-      "type": "select",
-      "default": "bd",
-      "description": "Beads backend for task persistence: bd (official) or none (degraded mode)",
-      "options": ["bd", "none"]
+    "useBeads": {
+      "type": "boolean",
+      "title": "Use Beads for Task Persistence",
+      "default": true,
+      "description": "Use Beads (bd) for task persistence. Disable to run in degraded mode without bd."
     },
     "agentsDir": {
       "type": "string",
+      "title": "Agents Directory",
       "default": ".agents",
       "description": "Directory where Flow stores specs, plans, and knowledge (e.g. .agents or specs)"
     }

--- a/hooks/detect-env.ps1
+++ b/hooks/detect-env.ps1
@@ -4,8 +4,17 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# CLAUDE_PLUGIN_OPTION_* are injected by the Claude Code harness from
+# plugin.json userConfig. Other hosts leave these unset, so default-fallback.
+$script:DEFAULT_ROOT_DIR = if ($env:CLAUDE_PLUGIN_OPTION_AGENTSDIR) { $env:CLAUDE_PLUGIN_OPTION_AGENTSDIR } else { '.agents' }
+$script:USE_BEADS = if ($env:CLAUDE_PLUGIN_OPTION_USEBEADS) { $env:CLAUDE_PLUGIN_OPTION_USEBEADS } else { 'true' }
+
 function Get-BeadsBackend {
     Write-Host "## Flow Environment Context"
+    if ($script:USE_BEADS -ne 'true') {
+        Write-Host "- **Beads Backend**: Disabled via plugin config (useBeads=false)"
+        return "disabled"
+    }
     $beads_bd = Get-Command bd -ErrorAction SilentlyContinue
 
     if ($beads_bd) {
@@ -22,7 +31,7 @@ function Get-BeadsBackend {
 }
 
 function Get-FlowRoot {
-    $rootDir = ".agents"
+    $rootDir = $script:DEFAULT_ROOT_DIR
     $setupStateFile = ".agents/setup-state.json"
     if (Test-Path $setupStateFile) {
         try {
@@ -31,13 +40,13 @@ function Get-FlowRoot {
                 $rootDir = ([string]$setupState.root_directory).TrimEnd('/', '\')
                 Write-Host "- **Flow Root**: $rootDir"
             } else {
-                Write-Host "- **Flow Root**: .agents (default, missing in setup-state)"
+                Write-Host "- **Flow Root**: $rootDir (default, missing in setup-state)"
             }
         } catch {
-            Write-Host "- **Flow Root**: .agents (default, error parsing setup-state)"
+            Write-Host "- **Flow Root**: $rootDir (default, error parsing setup-state)"
         }
     } else {
-        Write-Host "- **Flow Root**: .agents (default)"
+        Write-Host "- **Flow Root**: $rootDir (default)"
     }
     return $rootDir
 }
@@ -107,6 +116,10 @@ function Get-ContextIndex($rootDir) {
 function Get-ActiveWork($backend) {
     Write-Host ""
     Write-Host "### Active Work"
+    if ($backend -eq "disabled") {
+        Write-Host "- **Status**: Beads disabled via plugin config (useBeads=false)."
+        return
+    }
     if ($backend -eq "bd") {
         try {
             # ConvertFrom-Json may return a single object; wrap in @(...) so Select-Object sees an array

--- a/hooks/detect-env.sh
+++ b/hooks/detect-env.sh
@@ -12,7 +12,10 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # --- Configuration ---
-readonly DEFAULT_ROOT_DIR=".agents"
+# CLAUDE_PLUGIN_OPTION_* are injected by the Claude Code harness from
+# plugin.json userConfig. Other hosts leave these unset, so default-fallback.
+readonly DEFAULT_ROOT_DIR="${CLAUDE_PLUGIN_OPTION_AGENTSDIR:-.agents}"
+readonly USE_BEADS="${CLAUDE_PLUGIN_OPTION_USEBEADS:-true}"
 
 # --- Functions ---
 
@@ -39,6 +42,10 @@ safe_run() {
 
 detect_beads() {
     echo "## Flow Environment Context"
+    if [[ "${USE_BEADS}" != "true" ]]; then
+        echo "- **Beads Backend**: Disabled via plugin config (useBeads=false)"
+        return
+    fi
     if command -v bd >/dev/null 2>&1; then
         echo "- **Beads Backend**: Official (bd)"
     else
@@ -75,10 +82,10 @@ detect_project_root() {
             root_dir="${found_root}"
             msg="- **Flow Root**: ${root_dir}"
         else
-            msg="- **Flow Root**: .agents (default, missing in setup-state)"
+            msg="- **Flow Root**: ${root_dir} (default, missing in setup-state)"
         fi
     else
-        msg="- **Flow Root**: .agents (default)"
+        msg="- **Flow Root**: ${root_dir} (default)"
     fi
     # machine-readable path on stdout, message on stderr (or captured separately)
     # Actually, let's just echo the msg and then the path, but ensure main parses it correctly.
@@ -143,6 +150,10 @@ context_index() {
 active_work() {
     echo ""
     echo "### Active Work"
+    if [[ "${USE_BEADS}" != "true" ]]; then
+        echo "- **Status**: Beads disabled via plugin config (useBeads=false)."
+        return
+    fi
     if command -v bd >/dev/null 2>&1; then
         local ready
         ready=$(safe_run 2s bd ready --json)


### PR DESCRIPTION
## Summary

- **Unblocks `claude plugin install`** — the 0.20.0 `plugin.json` declared an invalid `userConfig` (`type: "select"`, missing `title` fields, unrecognized root `displayName`) and was rejected by Claude Code's Zod schema with five errors. Manifest now passes `claude plugin validate` cleanly.
- **Makes the toggles actually do something** — the `useBeads` and `agentsDir` user-config values are now read from `CLAUDE_PLUGIN_OPTION_*` env vars and gate the SessionStart hooks (`hooks/detect-env.sh` and `hooks/detect-env.ps1`). Previously they would have been decorative even after the schema fix.
- **Renamed `beadsBackend` (string + `options: ["bd", "none"]`) → `useBeads` (boolean)** because `userConfig` doesn't support enum/select types — the only valid `type` values are `string|number|boolean|directory|file`.

## Out of scope (follow-ups)

- #53 — gate direct `bd` calls in `commands/`, `skills/`, `tools/`, `agents/` on the same env var. SessionStart is the only consumer wired up here.
- The `setup-state.json` lookup is still hardcoded to `.agents/setup-state.json` regardless of `agentsDir` — project state still wins over user pref, which is probably the right precedence but worth knowing.
- Wiring `claude plugin validate` into `make check` / CI was deliberately skipped per request; this PR will land without that safety net.