### PR TITLE
fix(plugin): valid Claude agents field + gate manifest in make check (0.20.2)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
     {
       "name": "flow",
       "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "source": { "source": "local", "path": "./plugins/flow" },
       "policy": { "installation": "AVAILABLE" },
       "category": "Development",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "flow",
       "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "source": "./",
       "author": {
         "name": "cofin"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "author": {
     "name": "cofin"
   },
@@ -11,7 +11,6 @@
   "keywords": ["flow", "context-driven-development", "beads", "tdd", "ai-agent", "workflow", "spec-first", "skills", "slash-commands", "subagents"],
   "skills": ["./skills/"],
   "commands": ["./commands/"],
-  "agents": ["./agents/"],
   "hooks": "./hooks/hooks-claude.json",
   "userConfig": {
     "useBeads": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
   "author": { "name": "cofin" },
   "homepage": "https://github.com/cofin/flow",

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install markdownlint
         run: npm install -g markdownlint-cli2
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run quality checks
         run: make check
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ validate-codex-manifest:                           ## Validate Codex marketplace
 	@uv run --extra dev tools/validate-codex-manifest.py
 	@echo "${OK} Codex manifests valid"
 
+.PHONY: validate-claude-manifest
+validate-claude-manifest:                          ## Validate Claude Code plugin/marketplace manifests
+	@echo "${INFO} Validating Claude manifests..."
+	@uv run --extra dev tools/validate-claude-manifest.py
+	@echo "${OK} Claude manifests valid"
+
 .PHONY: sync-manifests
 sync-manifests:                                    ## Sync version strings across all manifests
 	@echo "${INFO} Syncing version strings..."
@@ -69,7 +75,7 @@ sync-manifests:                                    ## Sync version strings acros
 	@echo "${OK} Version strings in sync"
 
 .PHONY: check
-check: lint validate-skills validate-codex-manifest sync-manifests ## Run all quality checks (lint + validate)
+check: lint validate-skills validate-codex-manifest validate-claude-manifest sync-manifests ## Run all quality checks (lint + validate)
 	@echo "${OK} All checks passed"
 
 .PHONY: build

--- a/commands/flow-cleanup.md
+++ b/commands/flow-cleanup.md
@@ -1,3 +1,8 @@
+---
+description: Re-assess, reorganize, and optimize project context for implementation-readiness
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
 # flow:cleanup
 
 **Role:** The Groundskeeper

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "description": "Unified toolkit for Context-Driven Development with spec-first planning, TDD workflow, and Beads integration",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "contextFileName": "GEMINI.md",
   "plan": {
     "directory": ".agents"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Unified toolkit for Context-Driven Development",
   "type": "module",
   "main": ".opencode/plugins/flow.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flow"
-version = "0.20.1"
+version = "0.20.2"
 description = "Unified toolkit for Context-Driven Development"
 authors = [
   { name = "cofin" },
@@ -26,7 +26,7 @@ dev = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.20.1"
+current_version = "0.20.2"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -46,7 +46,7 @@ show_banner() {
     echo -e "${CYAN}"
     echo "╔══════════════════════════════════════════════════════════════╗"
     echo "║             Flow Framework - Plugin Installer                ║"
-    echo "║                       Version 0.20.1                         ║"
+    echo "║                       Version 0.20.2                         ║"
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo -e "${NC}"
 

--- a/tools/validate-claude-manifest.py
+++ b/tools/validate-claude-manifest.py
@@ -5,11 +5,17 @@ Wraps ``claude plugin validate <path>`` so CI fails on the same schema errors
 Claude Code's loader would surface at install time. Avoids hand-rolling a
 schema that drifts from the real validator.
 
-Exit 0 on clean; exit 1 if any target fails or ``claude`` is unavailable.
+Set ``SKIP_CLAUDE_VALIDATE=1`` to skip the check (e.g. on a developer
+machine without Claude Code installed). CI installs the CLI explicitly,
+so the skip is reserved for local convenience.
+
+Exit 0 on clean or when skipped; exit 1 if any target fails or ``claude``
+is missing without the skip flag set.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -39,9 +45,13 @@ def _validate(target: Path) -> bool:
 
 
 def main() -> int:
+    if os.environ.get("SKIP_CLAUDE_VALIDATE") == "1":
+        print("Skipping Claude manifest validation (SKIP_CLAUDE_VALIDATE=1).")
+        return 0
+
     if shutil.which("claude") is None:
         print("ERROR: 'claude' CLI not found on PATH.", file=sys.stderr)
-        print("Install Claude Code or skip with `SKIP_CLAUDE_VALIDATE=1`.", file=sys.stderr)
+        print("Install Claude Code (`npm install -g @anthropic-ai/claude-code`) or skip with `SKIP_CLAUDE_VALIDATE=1`.", file=sys.stderr)
         return 1
 
     failures = [t for t in TARGETS if not _validate(t)]

--- a/tools/validate-claude-manifest.py
+++ b/tools/validate-claude-manifest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Validate Claude Code plugin and marketplace manifests using the official ``claude`` CLI.
+
+Wraps ``claude plugin validate <path>`` so CI fails on the same schema errors
+Claude Code's loader would surface at install time. Avoids hand-rolling a
+schema that drifts from the real validator.
+
+Exit 0 on clean; exit 1 if any target fails or ``claude`` is unavailable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TARGETS: tuple[Path, ...] = (
+    REPO_ROOT / ".claude-plugin" / "plugin.json",
+    REPO_ROOT / ".claude-plugin" / "marketplace.json",
+)
+
+
+def _validate(target: Path) -> bool:
+    if not target.is_file():
+        print(f"  MISSING: {target}", file=sys.stderr)
+        return False
+    result = subprocess.run(
+        ["claude", "plugin", "validate", str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    return result.returncode == 0
+
+
+def main() -> int:
+    if shutil.which("claude") is None:
+        print("ERROR: 'claude' CLI not found on PATH.", file=sys.stderr)
+        print("Install Claude Code or skip with `SKIP_CLAUDE_VALIDATE=1`.", file=sys.stderr)
+        return 1
+
+    failures = [t for t in TARGETS if not _validate(t)]
+    if failures:
+        print(f"\n{len(failures)} manifest(s) failed Claude Code validation.", file=sys.stderr)
+        return 1
+    print(f"All {len(TARGETS)} Claude manifests valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate-claude-manifest.py
+++ b/tools/validate-claude-manifest.py
@@ -29,12 +29,12 @@ TARGETS: tuple[Path, ...] = (
 )
 
 
-def _validate(target: Path) -> bool:
+def _validate(claude_cmd: str, target: Path) -> bool:
     if not target.is_file():
         print(f"  MISSING: {target}", file=sys.stderr)
         return False
     result = subprocess.run(
-        ["claude", "plugin", "validate", str(target)],
+        [claude_cmd, "plugin", "validate", str(target)],
         capture_output=True,
         text=True,
         check=False,
@@ -49,12 +49,17 @@ def main() -> int:
         print("Skipping Claude manifest validation (SKIP_CLAUDE_VALIDATE=1).")
         return 0
 
-    if shutil.which("claude") is None:
+    # Use the full resolved path from `shutil.which`, not the bare name. On
+    # Windows, `claude` resolves to `claude.cmd` via PATHEXT, but
+    # `subprocess.run` does not honor PATHEXT, so passing the bare name
+    # raises FileNotFoundError even when the CLI is installed.
+    claude_cmd = shutil.which("claude")
+    if claude_cmd is None:
         print("ERROR: 'claude' CLI not found on PATH.", file=sys.stderr)
         print("Install Claude Code (`npm install -g @anthropic-ai/claude-code`) or skip with `SKIP_CLAUDE_VALIDATE=1`.", file=sys.stderr)
         return 1
 
-    failures = [t for t in TARGETS if not _validate(t)]
+    failures = [t for t in TARGETS if not _validate(claude_cmd, t)]
     if failures:
         print(f"\n{len(failures)} manifest(s) failed Claude Code validation.", file=sys.stderr)
         return 1

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ toml = [
 
 [[package]]
 name = "flow"
-version = "0.20.1"
+version = "0.20.2"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Drop the invalid `"agents": ["./agents/"]` from `.claude-plugin/plugin.json` introduced by #56 — Claude Code's schema rejects an array containing a directory path, breaking `/doctor` for installed users. Auto-discovery from `agents/*.md` is the canonical shape and was always active.
- Add missing YAML frontmatter to `commands/flow-cleanup.md` surfaced by the same validator run.
- Wire `claude plugin validate` into `make check` via a new `validate-claude-manifest` target, so the next schema regression fails CI instead of shipping.
- Bump to 0.20.2.

## Why a CLI-wrapping validator
`claude plugin validate` is the same loader Claude Code runs at install time. Wrapping it via `tools/validate-claude-manifest.py` means our local check tracks any future schema evolution Anthropic makes, with zero hand-rolled JSON Schema to drift. Each host's validator is the only authority on its own format — flow already does the same for Codex (`validate-codex-manifest.py`); this fills the Claude gap.

## Test plan
- [x] `make check` passes end-to-end (lint, skills, codex, claude, version sync)
- [x] `claude plugin validate .claude-plugin/plugin.json` → ✔ Validation passed
- [x] `claude plugin validate .claude-plugin/marketplace.json` → ✔ Validation passed
- [x] All 8 manifests in sync at 0.20.2
- [ ] CI quality-check matrix green