### PR TITLE
fix: triage bundle — agentsDir lookup, Codex legacy README, useBeads gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,14 @@ plan_mode_reasoning_effort = "high"
 <summary>Manual / repo-scoped install (legacy)</summary>
 <!-- markdownlint-restore -->
 
-If you can't use the native marketplace command (e.g. team policy, private fork), clone Flow and register a personal or repo-scoped marketplace entry pointing at the checkout:
+If you can't use the native marketplace command (e.g. team policy, private fork), clone Flow and register a marketplace entry that points at the checkout. Codex 0.125+ requires every local marketplace `path` to start with `./`, so place the marketplace manifest *next to* the cloned repo:
 
 ```bash
+mkdir -p ~/.codex/plugins
 git clone https://github.com/cofin/flow.git ~/.codex/plugins/flow
 ```
 
-Create `~/.agents/plugins/marketplace.json`:
+Create `~/.codex/plugins/marketplace.json`:
 
 ```json
 {
@@ -148,7 +149,7 @@ Create `~/.agents/plugins/marketplace.json`:
   "plugins": [
     {
       "name": "flow",
-      "source": { "source": "local", "path": "~/.codex/plugins/flow" },
+      "source": { "source": "local", "path": "./flow" },
       "policy": { "installation": "AVAILABLE" },
       "category": "Development"
     }
@@ -156,7 +157,7 @@ Create `~/.agents/plugins/marketplace.json`:
 }
 ```
 
-Restart Codex and run `/plugins` to verify Flow appears. See `.codex/INSTALL.md` in this repo for repo-scoped variants.
+The `./flow` path resolves relative to the manifest's directory. Restart Codex and run `/plugins` to verify Flow appears. See `.codex/INSTALL.md` in this repo for repo-scoped variants.
 
 </details>
 

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -13,6 +13,7 @@ You are an AI agent assistant for the Flow framework. Your mission is to execute
 - **No Fixes Without Root Cause Investigation**: Do NOT guess at fixes. Use systematic debugging.
 - **TDD Discipline**: Follow the Red-Green-Refactor cycle. Confirm failure for the right reason.
 - **Beads as Source of Truth**: NEVER write markers (`[x]`, `[~]`, etc.) to `spec.md` manually. Run `/flow:sync`.
+- **Beads Mode Gate**: Skip every `bd` invocation when SessionStart reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. In that mode, treat `spec.md` markers as the fallback source of truth (and write them directly), and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md` for the full rule.
 
 ## SUPERPOWERS INTEGRATION (MANDATORY)
 

--- a/agents/plan-generator.md
+++ b/agents/plan-generator.md
@@ -12,6 +12,7 @@ You are "The Planner", an AI agent assistant for the Flow framework. Your task i
 - **Worksheet Granularity**: Specific files, exact line numbers, and code samples for every logic change.
 - **Stateless Executor Test**: A plan is only 'Ready' if an agent with ZERO context can implement it 100% correctly based ONLY on the worksheet.
 - **TDD Requirement**: Each feature task MUST be broken into "Write Tests" followed by "Implement Feature".
+- **Beads Mode Gate**: Skip every `bd` invocation when SessionStart reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. In that mode, plans must rely on `spec.md` markers as source of truth — do not generate steps that assume a Beads backend exists. See `skills/flow/references/discipline.md`.
 
 ## SUPERPOWERS INTEGRATION (MANDATORY)
 

--- a/agents/prd-orchestrator.md
+++ b/agents/prd-orchestrator.md
@@ -12,6 +12,7 @@ You are "The Orchestrator", an AI architect for the Flow framework. Your primary
 - **No Deferred Research**: You are STRICTLY FORBIDDEN from creating "chapters" for research that should be completed during the PRD/Planning phase. ALL codebase investigation, API research, and architectural decisions MUST be done UPFRONT.
 - **Saga Architecture**: A PRD is a "Master Roadmap" (Saga) grouping 3-10 granular Flows (Chapters). Each flow must be refined into a **Worksheet** of code-level changes.
 - **Success Criteria**: A PRD is only complete when an agent with zero project context could take any of the resulting child plans and complete it 100% correctly without further questions.
+- **Beads Mode Gate**: Skip every `bd` invocation when SessionStart reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. In that mode, treat `spec.md` markers as fallback source of truth and avoid embedding `bd create`/`bd note` instructions into chapter plans. See `skills/flow/references/discipline.md`.
 
 ## SUPERPOWERS INTEGRATION (MANDATORY)
 

--- a/commands/flow-archive.md
+++ b/commands/flow-archive.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch
 
 # Flow Archive
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-completion` through the `flow` router.
 
 Archiving flow: **$ARGUMENTS**

--- a/commands/flow-archive.md
+++ b/commands/flow-archive.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch
 
 # Flow Archive
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-completion` through the `flow` router.
 
 Archiving flow: **$ARGUMENTS**

--- a/commands/flow-finish.md
+++ b/commands/flow-finish.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 
 # Flow Finish
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-completion` through the `flow` router.
 
 Completing flow: **$ARGUMENTS**

--- a/commands/flow-finish.md
+++ b/commands/flow-finish.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 
 # Flow Finish
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-completion` through the `flow` router.
 
 Completing flow: **$ARGUMENTS**

--- a/commands/flow-implement.md
+++ b/commands/flow-implement.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch
 
 # Flow Implement
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-execution` through the `flow` router.
 
 Implementing flow: **$ARGUMENTS**

--- a/commands/flow-implement.md
+++ b/commands/flow-implement.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch
 
 # Flow Implement
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-execution` through the `flow` router.
 
 Implementing flow: **$ARGUMENTS**

--- a/commands/flow-prd.md
+++ b/commands/flow-prd.md
@@ -5,8 +5,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, AskUserQuestion
 
 # Flow PRD
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 ## The Orchestrator Mandate

--- a/commands/flow-prd.md
+++ b/commands/flow-prd.md
@@ -5,6 +5,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, AskUserQuestion
 
 # Flow PRD
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 ## The Orchestrator Mandate

--- a/commands/flow-refine.md
+++ b/commands/flow-refine.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch
 
 # Flow Refine
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 Refining flow: **$ARGUMENTS**

--- a/commands/flow-refine.md
+++ b/commands/flow-refine.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch
 
 # Flow Refine
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 Refining flow: **$ARGUMENTS**

--- a/commands/flow-review.md
+++ b/commands/flow-review.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 
 # Flow Review
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-completion` through the `flow` router.
 
 Reviewing flow: **$ARGUMENTS**

--- a/commands/flow-review.md
+++ b/commands/flow-review.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 
 # Flow Review
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-completion` through the `flow` router.
 
 Reviewing flow: **$ARGUMENTS**

--- a/commands/flow-revise.md
+++ b/commands/flow-revise.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 
 # Flow Revise
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 Revising flow: **$ARGUMENTS**

--- a/commands/flow-revise.md
+++ b/commands/flow-revise.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 
 # Flow Revise
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 Revising flow: **$ARGUMENTS**

--- a/commands/flow-status.md
+++ b/commands/flow-status.md
@@ -5,8 +5,8 @@ allowed-tools: Read, Glob, Grep, Bash
 
 # Flow Status
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-sync-status` through the `flow` router.
 
 Display progress overview for all active flows.

--- a/commands/flow-status.md
+++ b/commands/flow-status.md
@@ -5,6 +5,8 @@ allowed-tools: Read, Glob, Grep, Bash
 
 # Flow Status
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-sync-status` through the `flow` router.
 
 Display progress overview for all active flows.

--- a/commands/flow-task.md
+++ b/commands/flow-task.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Bash
 
 # Flow Task
 
-**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
-
+> **Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+>
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 Creating ephemeral exploration flow: **$ARGUMENTS**

--- a/commands/flow-task.md
+++ b/commands/flow-task.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Write, Bash
 
 # Flow Task
 
+**Beads mode:** Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 > Lifecycle skill: use `flow-planning` through the `flow` router.
 
 Creating ephemeral exploration flow: **$ARGUMENTS**

--- a/commands/flow/archive.toml
+++ b/commands/flow/archive.toml
@@ -3,6 +3,9 @@ prompt = """
 ## Lifecycle Skill
 Use the `flow-completion` lifecycle skill through the `flow` router before carrying out this command.
 
+## Beads Mode Gate
+Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 ## 1.0 SYSTEM DIRECTIVE
 You are an AI agent assistant for the Flow spec-driven development framework. Your task is to archive a completed flow, ensure all artifacts are preserved, and elevate valuable learnings to the project-wide patterns.
 

--- a/commands/flow/refine.toml
+++ b/commands/flow/refine.toml
@@ -3,6 +3,9 @@ prompt = """
 ## Lifecycle Skill
 Use the `flow-planning` lifecycle skill through the `flow` router before carrying out this command.
 
+## Beads Mode Gate
+Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Refine `spec.md` task entries directly as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 ## 1.0 SYSTEM DIRECTIVE
 You are the **Flow Refiner**. Your task is to ensure every task in Beads has High-Definition detail (files, lines, snippets) for a "stateless" executor.
 

--- a/commands/flow/review.toml
+++ b/commands/flow/review.toml
@@ -3,6 +3,9 @@ prompt = """
 ## Lifecycle Skill
 Use the `flow-completion` lifecycle skill through the `flow` router before carrying out this command.
 
+## Beads Mode Gate
+Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Determine review range from git directly (e.g. `git log main..HEAD`) and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 ## 1.0 SYSTEM DIRECTIVE
 You are dispatching a code review for a Flow's implementation. Your task is to determine the correct git range from Beads, dispatch a review subagent, and present actionable results.
 

--- a/commands/flow/status.toml
+++ b/commands/flow/status.toml
@@ -3,6 +3,9 @@ prompt = """
 ## Lifecycle Skill
 Use the `flow-sync-status` lifecycle skill through the `flow` router before carrying out this command.
 
+## Beads Mode Gate
+Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Report status from `spec.md` markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 ## 1.0 SYSTEM DIRECTIVE
 You are an AI agent assistant for the Flow spec-driven development framework. Your task is to report the status of active flows using Beads as the primary source of truth.
 

--- a/commands/flow/sync.toml
+++ b/commands/flow/sync.toml
@@ -3,6 +3,9 @@ prompt = """
 ## Lifecycle Skill
 Use the `flow-sync-status` lifecycle skill through the `flow` router before carrying out this command.
 
+## Beads Mode Gate
+Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. `/flow:sync` is a no-op without a Beads backend — announce that briefly and exit cleanly. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 ## 1.0 SYSTEM DIRECTIVE
 You are an AI agent assistant for the Flow spec-driven development framework. Your task is to synchronize the current active backend task state back to the on-disk `spec.md` for a flow, refresh context documents based on the codebase, and optionally generate an export summary.
 

--- a/commands/flow/validate.toml
+++ b/commands/flow/validate.toml
@@ -3,6 +3,9 @@ prompt = """
 ## Lifecycle Skill
 Use the `flow-setup` lifecycle skill through the `flow` router before carrying out this command.
 
+## Beads Mode Gate
+Skip every `bd` invocation below when the SessionStart hook reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Validate `spec.md` markers as fallback source of truth and skip Beads consistency checks entirely. Never halt for missing Beads. See `skills/flow/references/discipline.md`.
+
 ## SYSTEM DIRECTIVE
 You are validating a Flow project's integrity. Check all files, Beads status, and flow consistency.
 

--- a/hooks/detect-env.ps1
+++ b/hooks/detect-env.ps1
@@ -32,7 +32,13 @@ function Get-BeadsBackend {
 
 function Get-FlowRoot {
     $rootDir = $script:DEFAULT_ROOT_DIR
-    $setupStateFile = ".agents/setup-state.json"
+    $setupStateFile = "$($script:DEFAULT_ROOT_DIR)/setup-state.json"
+    # Backward-compat: if the configured root has no setup-state but the
+    # default .agents/ does, read from there. Helps users who switched
+    # agentsDir after an existing setup.
+    if ((-not (Test-Path $setupStateFile)) -and (Test-Path ".agents/setup-state.json")) {
+        $setupStateFile = ".agents/setup-state.json"
+    }
     if (Test-Path $setupStateFile) {
         try {
             $setupState = Get-Content $setupStateFile -Raw | ConvertFrom-Json

--- a/hooks/detect-env.sh
+++ b/hooks/detect-env.sh
@@ -74,9 +74,16 @@ check_settings() {
 detect_project_root() {
     local root_dir="${DEFAULT_ROOT_DIR}"
     local msg=""
-    if [[ -f ".agents/setup-state.json" ]]; then
+    local state_file="${DEFAULT_ROOT_DIR}/setup-state.json"
+    # Backward-compat: if the configured root has no setup-state but the
+    # default .agents/ does, read from there. Helps users who switched
+    # agentsDir after an existing setup.
+    if [[ ! -f "${state_file}" && -f ".agents/setup-state.json" ]]; then
+        state_file=".agents/setup-state.json"
+    fi
+    if [[ -f "${state_file}" ]]; then
         local found_root
-        found_root=$(grep -o '"root_directory": "[^"]*"' .agents/setup-state.json | cut -d'"' -f4 || true)
+        found_root=$(grep -o '"root_directory": "[^"]*"' "${state_file}" | cut -d'"' -f4 || true)
         found_root="${found_root%/}"
         if [[ -n "${found_root}" ]]; then
             root_dir="${found_root}"

--- a/skills/flow/references/discipline.md
+++ b/skills/flow/references/discipline.md
@@ -137,6 +137,26 @@ BEFORE claiming any status:
 
 ---
 
+## Beads Mode Iron Law
+
+```text
+NO `bd` INVOCATIONS WHEN BEADS IS DISABLED OR MISSING
+```
+
+The SessionStart hook (`hooks/detect-env.sh`) emits one of three Beads-backend signals into the agent context:
+
+| Hook signal | Action |
+|---|---|
+| `Beads Backend: Official (bd)` | Proceed normally — `bd` is the source of truth. |
+| `Beads Backend: Missing (None)` | Skip every `bd` invocation. Treat `spec.md` markers as fallback source of truth. |
+| `Beads Backend: Disabled via plugin config (useBeads=false)` | Skip every `bd` invocation. Treat `spec.md` markers as fallback source of truth. |
+
+**Never halt for missing Beads.** Degrade gracefully: read state from `spec.md` markers (`[ ]`, `[~]`, `[x]`, `[!]`, `[-]`), record progress by editing those markers directly, skip notes/learnings that would otherwise go into Beads, and skip `/flow:sync` (it's a no-op without a backend).
+
+**Why this exists:** The plugin manifest exposes a `useBeads` userConfig toggle and the host can also lack `bd` entirely. Before this rule, every flow command shelled out to `bd` unconditionally — toggling `useBeads=false` only suppressed SessionStart context while every command still emitted "command not found" or stored garbage.
+
+---
+
 ## Critical Thinking Iron Law
 
 ```text

--- a/templates/opencode/agents/flow.md
+++ b/templates/opencode/agents/flow.md
@@ -95,10 +95,11 @@ Use the matching Flow workflow whenever the user expresses the intent, even if t
 1. **Read patterns.md** before starting work
 2. **Log learnings** as you discover them
 3. **Use TDD** - tests first, then implementation
-4. **Beads is source of truth** - Never write markers to spec.md
-5. **Use Superpowers subagents for implement** when available (`superpowers:subagent-driven-development`)
-6. **Use `flow:apilookup` proactively** for external API/version/doc/migration questions
-7. **Flow specs/plans live in `.agents/specs/`** - never use `docs/superpowers/specs/`
-8. **Local commits** - Never push automatically
-9. **Use `flow-refine` before lightweight execution** when a plan is too coarse for correct first-pass implementation
-10. **Preserve subagent context** - pass spec/PRD, patterns, knowledge, learnings, affected files, and verification requirements when delegating
+4. **Beads is source of truth** - Never write markers to spec.md (when Beads is enabled)
+5. **Beads mode gate** - Skip every `bd` invocation when SessionStart reports `Beads Backend: Missing (None)` or `Disabled via plugin config (useBeads=false)`. Treat spec.md markers as fallback source of truth and skip `/flow:sync`. Never halt for missing Beads.
+6. **Use Superpowers subagents for implement** when available (`superpowers:subagent-driven-development`)
+7. **Use `flow:apilookup` proactively** for external API/version/doc/migration questions
+8. **Flow specs/plans live in `.agents/specs/`** - never use `docs/superpowers/specs/`
+9. **Local commits** - Never push automatically
+10. **Use `flow-refine` before lightweight execution** when a plan is too coarse for correct first-pass implementation
+11. **Preserve subagent context** - pass spec/PRD, patterns, knowledge, learnings, affected files, and verification requirements when delegating


### PR DESCRIPTION
## Summary

Bundled fixes from the open-issue triage. **Closes #50, #53, #55.** (#37 closed separately as already-addressed; #48 deferred per maintainer preference.)

### #55 — `agentsDir`-aware setup-state lookup
`hooks/detect-env.{sh,ps1}` hardcoded `.agents/setup-state.json` even after #54 wired `CLAUDE_PLUGIN_OPTION_AGENTSDIR` into `DEFAULT_ROOT_DIR`. With `agentsDir=specs` configured, the hook silently fell through to the "(default)" branch, masking the user's chosen root. Lookup now uses `${DEFAULT_ROOT_DIR}/setup-state.json` first, with `.agents/setup-state.json` as a backward-compat fallback for users who switched `agentsDir` mid-project.

### #50 — Valid Codex 0.125+ legacy install path
README's legacy/manual Codex install block placed the marketplace manifest at `~/.agents/plugins/marketplace.json` and used `"path": "~/.codex/plugins/flow"`. Codex 0.125+ rejects any local marketplace path that isn't prefixed with `./`. Restructured: marketplace manifest goes next to the cloned repo at `~/.codex/plugins/marketplace.json` with `"path": "./flow"`, which resolves correctly relative to the manifest's directory.

### #53 — Gate every `bd` invocation on `useBeads`/availability
Until now, only `hooks/detect-env.{sh,ps1}` consulted the `useBeads` userConfig (3 references in the entire repo); every flow command, agent, and TOML mirror shelled out to `bd` unconditionally. Toggling `useBeads=false` suppressed the SessionStart context block but every command still emitted `command not found` — the toggle was effectively a no-op. Centralized the rule:

- **`skills/flow/references/discipline.md`** — new `Beads Mode Iron Law` section alongside TDD/Debugging/Verification, with a signal table mapping the three SessionStart hook outputs (Official / Missing / Disabled) to the required agent behavior.
- **`agents/{executor,plan-generator,prd-orchestrator}.md`** + **`templates/opencode/agents/flow.md`** — gate added to each agent's IRON LAWS / ZERO-AMBIGUITY MANDATE / Critical Rules block.
- **`commands/flow-{implement,status,archive,finish,task,prd,refine,review,revise}.md`** + **`commands/flow/{archive,review,validate,refine,status,sync}.toml`** mirrors — short Beads-mode preamble pointing to the canonical rule, so an agent reading a single command file still sees the gate even without the discipline reference loaded. Markdown preambles are merged into the existing lifecycle-skill blockquote (one continuous callout, MD028-clean).

Falls back to `spec.md` markers (`[ ]`, `[~]`, `[x]`, `[!]`, `[-]`) as the source of truth in degraded mode. Never halts for missing Beads.

## Test plan
- [x] `make check` passes (lint, skills, codex, version sync) — twice (initial and after the MD028 correction)
- [x] `hooks/detect-env.sh` smoke-tested for all three lookup paths in `/tmp/flow-test/`:
  - default `.agents/` + `.agents/setup-state.json` → reads correctly
  - custom `agentsDir=specs` + `specs/setup-state.json` → reads correctly (the bug fix)
  - custom `agentsDir=specs` + no state file → "(default)" branch as expected
- [ ] User-side: re-run `claude plugin install flow@flow-marketplace` and confirm `/doctor` no longer flags either Codex or `agentsDir` issue
- [ ] Smoke-test `useBeads=false` mode: install plugin with toggle off, run `/flow:status` and `/flow:task` — expect graceful degraded-mode output instead of `bd: command not found`